### PR TITLE
Add link to CERN ops tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Other sources of tools
 
 * GoDaddy: https://github.com/godaddy/openstack-puppet/tree/master/tools
 * NeCTAR: https://github.com/NeCTAR-RC/nectar-tools
+* CERN: https://github.com/cernops


### PR DESCRIPTION
Added a link to CERN's open source ops tools for OpenStack.